### PR TITLE
Fix GDPR consent banner displaying under Plone toolbar

### DIFF
--- a/base/src/scss/common/_com-cookies.scss
+++ b/base/src/scss/common/_com-cookies.scss
@@ -1,5 +1,5 @@
 #gdpr-consent-banner {
-    z-index: 98;
+    z-index: 999999;
     padding: 50px 25px;
     background: #fff;
     position: fixed;


### PR DESCRIPTION
See : 
<img width="1412" alt="capture" src="https://user-images.githubusercontent.com/1101273/215476399-00aef85a-a9f3-401b-8e24-5dbe34347566.png">
